### PR TITLE
refac: NDinterface

### DIFF
--- a/UMA-Bots/Configuration-Change/README.md
+++ b/UMA-Bots/Configuration-Change/README.md
@@ -24,8 +24,8 @@ These tests can be run using npm run tx <TX_HASH> :
 ### Ethereum Mainnet
 
 The agent behaviour can be verified with the following transactions by running `npm run tx <TX_HASH>`:
-<!-- - [0x10e5c318414dccbc2172ce624afd0a4ae46fa538ef6b21522f2e87991f621e60](https://etherscan.io/tx/0x10e5c318414dccbc2172ce624afd0a4ae46fa538ef6b21522f2e87991f621e60) (1 finding - `RootBundleDisputed` was emitted)
-- [0x312985c7e8a363079c3ae416f8e30a3caa4d4ddee61ac9c2c07f2a637655916d](https://etherscan.io/tx/0x312985c7e8a363079c3ae416f8e30a3caa4d4ddee61ac9c2c07f2a637655916d) (2 findings - `RootBundleDisputed` was emitted 2 times with different parameters)  -->
+- [0xebff6f85c589c4fb493f24560b007a0c1a2c9be0e930c548ca8dd10adbbe504a](https://etherscan.io/tx/0xebff6f85c589c4fb493f24560b007a0c1a2c9be0e930c548ca8dd10adbbe504a) (1 finding - `BondSet` was emitted by the `HubPool` contract)
+- [0x35e9ebe1585c2ff4c10a91f2060ee7ec1bd6af5568ff16e45256c62904b27d17](https://etherscan.io/tx/0x35e9ebe1585c2ff4c10a91f2060ee7ec1bd6af5568ff16e45256c62904b27d17) (2 findings - `SetXDomainAdmin` and `SetHubPool` were emitted by the `SpokePool` contract) 
 
  ### Goerli Testnet (PoC)
 

--- a/UMA-Bots/Configuration-Change/src/agent.ts
+++ b/UMA-Bots/Configuration-Change/src/agent.ts
@@ -6,7 +6,7 @@ import {
   HUBPOOL_MONITORED_EVENTS,
   SPOKEPOOL_MONITORED_EVENTS,
 } from "./utils";
-import { createAddress, NetworkManager } from "forta-agent-tools";
+import { NetworkManager } from "forta-agent-tools";
 import { NM_DATA, NetworkDataInterface } from "./network";
 
 const networkManagerCurr = new NetworkManager(NM_DATA);
@@ -30,8 +30,8 @@ export function provideHandleTransaction(
     let eventNameToAbiSpokePool = generateDictNameToAbi(monitoredSpokePoolEvents);
     const findings: Finding[] = [];
     // HubPool configurations
-    if (networkManager.get("hubPoolAddr") != createAddress("0x00")) {
-      const hubPoolEventTxns = txEvent.filterLog(monitoredHubPoolEvents, networkManager.get("hubPoolAddr"));
+    if (networkManager.get("addresses").length == 2) {
+      const hubPoolEventTxns = txEvent.filterLog(monitoredHubPoolEvents, networkManager.get("addresses")[1]);
       hubPoolEventTxns.forEach((actualEventTxn) => {
         let thisFindingMetadata = getEventMetadata(
           actualEventTxn.eventFragment.name,
@@ -42,7 +42,7 @@ export function provideHandleTransaction(
       });
     }
     // SpokePool configurations
-    const spokePoolEventTxns = txEvent.filterLog(monitoredSpokePoolEvents, networkManager.get("spokePoolAddr"));
+    const spokePoolEventTxns = txEvent.filterLog(monitoredSpokePoolEvents, networkManager.get("addresses")[0]);
     spokePoolEventTxns.forEach((actualEventTxn) => {
       let thisFindingMetadata = getEventMetadata(
         actualEventTxn.eventFragment.name,

--- a/UMA-Bots/Configuration-Change/src/hubpool-tests.spec.ts
+++ b/UMA-Bots/Configuration-Change/src/hubpool-tests.spec.ts
@@ -14,12 +14,8 @@ const RANDOM_ADDRESSES = [createAddress("0x12"), createAddress("0x54")];
 const TRANSFER_EVENT_ABI = "event Transfer(address,uint)";
 const TEST_HUBPOOL_ADDR: string = createAddress("0x23");
 const TEST_SPOKEPOOL_ADDR: string = createAddress("0x46");
-const EMPTY_ADDRESS = createAddress("0x00");
 const MOCK_NM_DATA: Record<number, NetworkDataInterface> = {
-  0: { hubPoolAddr: TEST_HUBPOOL_ADDR, spokePoolAddr: TEST_SPOKEPOOL_ADDR },
-};
-const MOCK_L2_NM_DATA: Record<number, NetworkDataInterface> = {
-  0: { hubPoolAddr: EMPTY_ADDRESS, spokePoolAddr: TEST_SPOKEPOOL_ADDR },
+  0: { addresses: [TEST_SPOKEPOOL_ADDR, TEST_HUBPOOL_ADDR] },
 };
 
 describe("Detection of HubPool events on L1", () => {

--- a/UMA-Bots/Configuration-Change/src/multiple-findings.spec.ts
+++ b/UMA-Bots/Configuration-Change/src/multiple-findings.spec.ts
@@ -16,10 +16,10 @@ const TEST_HUBPOOL_ADDR: string = createAddress("0x23");
 const TEST_SPOKEPOOL_ADDR: string = createAddress("0x46");
 const EMPTY_ADDRESS = createAddress("0x00");
 const MOCK_NM_DATA: Record<number, NetworkDataInterface> = {
-  0: { hubPoolAddr: TEST_HUBPOOL_ADDR, spokePoolAddr: TEST_SPOKEPOOL_ADDR },
+  0: { addresses: [TEST_SPOKEPOOL_ADDR, TEST_HUBPOOL_ADDR] },
 };
 const MOCK_L2_NM_DATA: Record<number, NetworkDataInterface> = {
-  0: { hubPoolAddr: EMPTY_ADDRESS, spokePoolAddr: TEST_SPOKEPOOL_ADDR },
+  0: { addresses: [TEST_SPOKEPOOL_ADDR] },
 };
 
 describe("Detection of HubPool events on L1", () => {
@@ -53,7 +53,8 @@ describe("Detection of HubPool events on L1", () => {
     const txEvent: TransactionEvent = new TestTransactionEvent()
       .setFrom(RANDOM_ADDRESSES[1])
       .addEventLog(SPOKEPOOL_MONITORED_EVENTS[0], TEST_SPOKEPOOL_ADDR, [RANDOM_ADDRESSES[0]])
-      .addEventLog(SPOKEPOOL_MONITORED_EVENTS[3], TEST_SPOKEPOOL_ADDR, ["123"]);
+      .addEventLog(SPOKEPOOL_MONITORED_EVENTS[3], TEST_SPOKEPOOL_ADDR, ["123"])
+      .addEventLog(TRANSFER_EVENT_ABI, TEST_SPOKEPOOL_ADDR, [RANDOM_ADDRESSES[0], "123"]);
 
     let thisFindingMetadataEvent1 = getEventMetadataFromAbi(SPOKEPOOL_MONITORED_EVENTS[0], [RANDOM_ADDRESSES[0]]);
     let thisFindingMetadataEvent2 = getEventMetadataFromAbi(SPOKEPOOL_MONITORED_EVENTS[3], ["123"]);

--- a/UMA-Bots/Configuration-Change/src/network.ts
+++ b/UMA-Bots/Configuration-Change/src/network.ts
@@ -1,9 +1,8 @@
 import { Network } from "forta-agent";
-import { createAddress } from "forta-agent-tools";
-const EMPTY_ADDRESS = createAddress("0x00");
+
 const POC_HUBPOOL_ADDRESS = "0x68715254125884dE73391b6bBaf0776Cf634c24D";
 const POC_SPOKEPOOL_ADDRESS = "0x4972B5D2B9ac17784428701de1113d5A42970521";
-const HUBPOOL_ADDRESS = "0xc186fa914353c44b2e33ebe05f21846f1048beda";
+const MAINNET_HUBPOOL = "0xc186fa914353c44b2e33ebe05f21846f1048beda";
 const MAINNET_SPOKEPOOL = "0x4D9079Bb4165aeb4084c526a32695dCfd2F77381";
 const OPTIMISM_SPOKEPOOL = "0xa420b2d1c0841415A695b81E5B867BCD07Dff8C9";
 const POLYGON_SPOKEPOOL = "0x69B5c72837769eF1e7C164Abc6515DcFf217F920";
@@ -11,16 +10,19 @@ const BOBA_SPOKEPOOL = "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58";
 const ARBITRUM_SPOKEPOOL = "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C";
 const BOBA_CHAIN_ID = 288;
 
+/*
+ * @dev The first element in the "addresses" array is always the SpokePool contract address.
+ * @dev In case a HubPool is deployed on the chain, its address will be the second element in the "addresses" array
+ */
 export interface NetworkDataInterface {
-  hubPoolAddr: string;
-  spokePoolAddr: string;
+  addresses: string[];
 }
 
 export const NM_DATA: Record<number, NetworkDataInterface> = {
-  [Network.MAINNET]: { hubPoolAddr: HUBPOOL_ADDRESS, spokePoolAddr: MAINNET_SPOKEPOOL },
-  [Network.OPTIMISM]: { hubPoolAddr: EMPTY_ADDRESS, spokePoolAddr: OPTIMISM_SPOKEPOOL },
-  [Network.ARBITRUM]: { hubPoolAddr: EMPTY_ADDRESS, spokePoolAddr: ARBITRUM_SPOKEPOOL },
-  [Network.POLYGON]: { hubPoolAddr: EMPTY_ADDRESS, spokePoolAddr: POLYGON_SPOKEPOOL },
-  [BOBA_CHAIN_ID]: { hubPoolAddr: EMPTY_ADDRESS, spokePoolAddr: BOBA_SPOKEPOOL },
-  [Network.GOERLI]: { hubPoolAddr: POC_HUBPOOL_ADDRESS, spokePoolAddr: POC_SPOKEPOOL_ADDRESS }, //PoC
+  [Network.MAINNET]: { addresses: [MAINNET_SPOKEPOOL, MAINNET_HUBPOOL] },
+  [Network.OPTIMISM]: { addresses: [OPTIMISM_SPOKEPOOL] },
+  [Network.ARBITRUM]: { addresses: [ARBITRUM_SPOKEPOOL] },
+  [Network.POLYGON]: { addresses: [POLYGON_SPOKEPOOL] },
+  [BOBA_CHAIN_ID]: { addresses: [BOBA_SPOKEPOOL] },
+  [Network.GOERLI]: { addresses: [POC_SPOKEPOOL_ADDRESS, POC_HUBPOOL_ADDRESS] }, //PoC
 };

--- a/UMA-Bots/Configuration-Change/src/spokepool-tests.spec.ts
+++ b/UMA-Bots/Configuration-Change/src/spokepool-tests.spec.ts
@@ -15,9 +15,8 @@ const TRANSFER_EVENT_ABI = "event Transfer(address,uint)";
 const TEST_HUBPOOL_ADDR: string = createAddress("0x23");
 const TEST_SPOKEPOOL_ADDR: string = createAddress("0x46");
 const MOCK_NM_DATA: Record<number, NetworkDataInterface> = {
-  0: { hubPoolAddr: TEST_HUBPOOL_ADDR, spokePoolAddr: TEST_SPOKEPOOL_ADDR },
+  0: { addresses: [TEST_SPOKEPOOL_ADDR, TEST_HUBPOOL_ADDR] },
 };
-
 const networkManagerTest = new NetworkManager(MOCK_NM_DATA, 0);
 
 describe("SpokePool configuration changes detection bot", () => {


### PR DESCRIPTION
# Bot name here

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] New Bot
- [ ] Fix a bot error
- [ ] Update a bot logic/test/documentation
- [ ] Code style update (formatting, renaming)
- [ ] Other (please describe):

## New Bot PR readiness

- [ ] `npm install` command works (i.e. package-lock is updated properly)
- [ ] The `name` and `description` fields of `package.json` describe the bot properly
- [ ] All the libraries listed in `package.json` are being used
- [ ] All the development libraries are in `devDependencies` section of `package.json`
- [ ] The bot README is updated
- [ ] The bot README sufficiently describes what the bot does
- [ ] All the alerts that the bot emits are listed in the README
- [ ] The txn/block examples listed in the README generate the expected findings
- [ ] Code is easy to follow and/or properly commented
- [ ] Bot contains tests
- [ ] All tests pass when running `npm test`
- [ ] Tests are not making real network calls (i.e. network interaction is properly mocked)
- [ ] Tests cover all the paths (i.e. negative & positive test cases)
- [ ] When the tests complete, no warning/errors are shown
- [ ] `npm start` works without errors when executed using a jsonRpcUrl for each of the networks specified in the README
- [ ] The networks specified in the README and the networks are listed in the `package.json` are the same
- [ ] The code does what the README describes
- [ ] Network calls are properly being cached (if duplicated calls can occur)
- [ ] A performance review has been done (e.g. `Promise.all` is used whenever possible)
- [ ] The findings fields are filled out correctly
- [ ] Findings `protocol` is specified (if the bot is for a specific one)
- [ ] `metadata` of the findings contains all the information needed.
- [ ] The SDK methods are being used appropriately (e.g. `filterLog`, `filterFunction`, `getEthersProvider`)
- [ ] `ABI`s match the contracts used / `args` used from `LogDescriptions` exists in the `ABI`s
- [ ] The bot follows Forta recommended [best practices](https://docs.forta.network/en/latest/best-practices/)
- [ ] Bot can recover from failed error calls when they can fail (e.g. errors are being caught on calls that can fail)
- [ ] `repository` is added in the `package.json`

## Comments (optional)

If there is some useful information or important note for reviewing/understanding this bot please describe it here.
